### PR TITLE
Upgrade h2 and fix DBURL

### DIFF
--- a/grida-server/pom.xml
+++ b/grida-server/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.3.169</version>
+            <version>1.4.196</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/grida-server/src/main/java/fr/insalyon/creatis/grida/server/dao/H2DAOFactory.java
+++ b/grida-server/src/main/java/fr/insalyon/creatis/grida/server/dao/H2DAOFactory.java
@@ -53,7 +53,7 @@ public class H2DAOFactory extends DAOFactory {
     private static final Logger logger = Logger.getLogger(H2DAOFactory.class);
     private static H2DAOFactory instance;
     private final String DRIVER = "org.h2.Driver";
-    private final String DBURL = "jdbc:h2:db/vlet-agent.db";
+    private final String DBURL = "jdbc:h2:./db/vlet-agent.db";
     private Connection connection;
 
     public static H2DAOFactory getInstance() {


### PR DESCRIPTION
This is a minor patch to upgrade h2 in grida-server, to prepare upcoming changes. I prefer to separate it from the rest so that it stands out :
- As we'll need to use Grida from Moteurlite/GASW, h2 versions have to match between projects. This requires upgrading h2 from 1.3.169 to 1.4.196 in grida-server/pom.xml.
- But when using this h2 new version, `H2DAOFactory.java:DriverManager.getConnection()` was now failing with :
```
org.h2.jdbc.JdbcSQLException: A file path that is implicitly relative to the current working directory is not allowed in the database URL "jdbc:h2:db/vlet-agent.db;create=true". Use an absolute path, ~/name, ./name, or the baseDir setting instead. [90011-196]
```

The simplest fix just consists in making the relative path explicit with an extra "./" in DBURL. This extra constraint appears entirely related to the lib version upgrade, and a quick search for `jdbc:h2` in the rest of the codebase shows that this h2 instance in Grida was likely the only one impacted by this change : all other h2 file paths in other VIP projects seem to be absolute.
