### PR TITLE
New getPathInfo command

### DIFF
--- a/grida-client/src/main/java/fr/insalyon/creatis/grida/client/GRIDAClient.java
+++ b/grida-client/src/main/java/fr/insalyon/creatis/grida/client/GRIDAClient.java
@@ -172,6 +172,57 @@ public class GRIDAClient extends AbstractGRIDAClient {
     }
 
     /**
+     * Gets path information for the provided path.
+     *
+     * @param pathName Path to resolve
+     * @return File or directory type
+     * @throws GRIDAClientException
+     */
+    public GridData.Type getPathInfo(String pathName) throws GRIDAClientException {
+        List<String> pathsList = new ArrayList<String>();
+        pathsList.add(pathName);
+        return getPathInfo(pathsList).get(0);
+    }
+
+    /**
+     * Gets path information for the list of paths provided.
+     *
+     * @param pathsList List of paths to resolve
+     * @return List of file or directory type respectively to the list of files
+     * @throws GRIDAClientException
+     */
+    public List<GridData.Type> getPathInfo(List<String> pathsList) throws GRIDAClientException {
+        try {
+            Communication communication = getCommunication();
+
+            StringBuilder sb = new StringBuilder();
+            for (String fileName : pathsList) {
+                if (!sb.toString().isEmpty()) {
+                    sb.append(Constants.MSG_SEP_2);
+                }
+                sb.append(Util.removeLfnFromPath(fileName));
+            }
+            communication.sendMessage(
+                    ExecutorConstants.COM_GET_PATH_INFO + Constants.MSG_SEP_1
+                            + proxyPath + Constants.MSG_SEP_1 + sb.toString());
+            communication.sendEndOfMessage();
+
+            String types = communication.getMessage();
+            communication.close();
+
+            List<GridData.Type> typesList = new ArrayList<GridData.Type>();
+            for (String type : types.split(Constants.MSG_SEP_1)) {
+                typesList.add(GridData.Type.valueOf(type));
+            }
+
+            return typesList;
+
+        } catch (IOException ex) {
+            throw new GRIDAClientException(ex);
+        }
+    }
+
+    /**
      * Gets the modification date of the provided file.
      * 
      * @param fileName File name to get the modification date

--- a/grida-client/src/main/java/fr/insalyon/creatis/grida/client/GRIDAClient.java
+++ b/grida-client/src/main/java/fr/insalyon/creatis/grida/client/GRIDAClient.java
@@ -39,7 +39,6 @@ import fr.insalyon.creatis.grida.common.Constants;
 import fr.insalyon.creatis.grida.common.ExecutorConstants;
 import fr.insalyon.creatis.grida.common.bean.GridData;
 import fr.insalyon.creatis.grida.common.bean.GridPathInfo;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/grida-client/src/main/java/fr/insalyon/creatis/grida/client/GRIDAClient.java
+++ b/grida-client/src/main/java/fr/insalyon/creatis/grida/client/GRIDAClient.java
@@ -215,7 +215,9 @@ public class GRIDAClient extends AbstractGRIDAClient {
             List<GridPathInfo> pathInfos = new ArrayList<GridPathInfo>();
             for (String data : response.split(Constants.MSG_SEP_1)) {
                 String[] d = data.split(Constants.MSG_SEP_2);
-                pathInfos.add(new GridPathInfo(Boolean.valueOf(d[0]), GridData.Type.valueOf(d[1])));
+                boolean exist = Boolean.valueOf(d[0]);
+                GridData.Type type = exist ? GridData.Type.valueOf(d[1]) : null;
+                pathInfos.add(new GridPathInfo(exist, type));
             }
 
             return pathInfos;

--- a/grida-client/src/main/java/fr/insalyon/creatis/grida/client/GRIDAClient.java
+++ b/grida-client/src/main/java/fr/insalyon/creatis/grida/client/GRIDAClient.java
@@ -38,6 +38,8 @@ import fr.insalyon.creatis.grida.common.Communication;
 import fr.insalyon.creatis.grida.common.Constants;
 import fr.insalyon.creatis.grida.common.ExecutorConstants;
 import fr.insalyon.creatis.grida.common.bean.GridData;
+import fr.insalyon.creatis.grida.common.bean.GridPathInfo;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -175,10 +177,10 @@ public class GRIDAClient extends AbstractGRIDAClient {
      * Gets path information for the provided path.
      *
      * @param pathName Path to resolve
-     * @return File or directory type
+     * @return Whether the path exists, and is a folder or a file
      * @throws GRIDAClientException
      */
-    public GridData.Type getPathInfo(String pathName) throws GRIDAClientException {
+    public GridPathInfo getPathInfo(String pathName) throws GRIDAClientException {
         List<String> pathsList = new ArrayList<String>();
         pathsList.add(pathName);
         return getPathInfo(pathsList).get(0);
@@ -191,7 +193,7 @@ public class GRIDAClient extends AbstractGRIDAClient {
      * @return List of file or directory type respectively to the list of files
      * @throws GRIDAClientException
      */
-    public List<GridData.Type> getPathInfo(List<String> pathsList) throws GRIDAClientException {
+    public List<GridPathInfo> getPathInfo(List<String> pathsList) throws GRIDAClientException {
         try {
             Communication communication = getCommunication();
 
@@ -207,15 +209,16 @@ public class GRIDAClient extends AbstractGRIDAClient {
                             + proxyPath + Constants.MSG_SEP_1 + sb.toString());
             communication.sendEndOfMessage();
 
-            String types = communication.getMessage();
+            String response = communication.getMessage();
             communication.close();
 
-            List<GridData.Type> typesList = new ArrayList<GridData.Type>();
-            for (String type : types.split(Constants.MSG_SEP_1)) {
-                typesList.add(GridData.Type.valueOf(type));
+            List<GridPathInfo> pathInfos = new ArrayList<GridPathInfo>();
+            for (String data : response.split(Constants.MSG_SEP_1)) {
+                String[] d = data.split(Constants.MSG_SEP_2);
+                pathInfos.add(new GridPathInfo(Boolean.valueOf(d[0]), GridData.Type.valueOf(d[1])));
             }
 
-            return typesList;
+            return pathInfos;
 
         } catch (IOException ex) {
             throw new GRIDAClientException(ex);

--- a/grida-client/src/main/java/fr/insalyon/creatis/grida/client/GRIDAClientMain.java
+++ b/grida-client/src/main/java/fr/insalyon/creatis/grida/client/GRIDAClientMain.java
@@ -32,8 +32,11 @@ package fr.insalyon.creatis.grida.client;
 
 import fr.insalyon.creatis.grida.common.bean.CachedFile;
 import fr.insalyon.creatis.grida.common.bean.GridData;
+import fr.insalyon.creatis.grida.common.bean.GridPathInfo;
 import fr.insalyon.creatis.grida.common.bean.Operation;
 import fr.insalyon.creatis.grida.common.bean.ZombieFile;
+
+
 import java.io.File;
 import java.text.DateFormat;
 import java.util.Arrays;
@@ -204,7 +207,8 @@ public class GRIDAClientMain {
         }
         break;
         case "getpathinfo":
-            result = client.getPathInfo(firstArg).name(); // XXX ?
+            GridPathInfo pathInfo = client.getPathInfo(firstArg);
+            result = pathInfo.exist() ? pathInfo.getType().name() : "Not found.";
             break;
         case "getmoddate":
             result = Long.toString(client.getModificationDate(firstArg));
@@ -356,6 +360,7 @@ public class GRIDAClientMain {
             "getfile",
             "getfolder",
             "list",
+            "getpathinfo",
             "getmoddate",
             "upload",
             "uploadtoses",
@@ -383,6 +388,7 @@ public class GRIDAClientMain {
             2, // "getfile",
             3, // "getfolder",
             2, // "list",
+            1, // "getpathinfo",
             1, // "getmoddate",
             2, // "upload",
             3, // "uploadtoses",

--- a/grida-client/src/main/java/fr/insalyon/creatis/grida/client/GRIDAClientMain.java
+++ b/grida-client/src/main/java/fr/insalyon/creatis/grida/client/GRIDAClientMain.java
@@ -147,6 +147,7 @@ public class GRIDAClientMain {
             " getFile <remoteFile> <localDir>\n" +
             " getFolder <remoteDir> <localDir> <1 to zip it, or else 0>\n" +
             " list <dir> <1 if refresh, or else 0>\n" +
+            " getPathInfo <pathname>\n" +
             " getModDate <filename>\n" +
             " upload <localFile> <remoteDir>\n" +
             " uploadToSes <localFile> <remoteDir> <storageElement>\n" +
@@ -202,6 +203,9 @@ public class GRIDAClientMain {
             result = list(client, firstArg, refresh, false);
         }
         break;
+        case "getpathinfo":
+            result = client.getPathInfo(firstArg).name(); // XXX ?
+            break;
         case "getmoddate":
             result = Long.toString(client.getModificationDate(firstArg));
             break;

--- a/grida-client/src/main/java/fr/insalyon/creatis/grida/client/GRIDAClientMain.java
+++ b/grida-client/src/main/java/fr/insalyon/creatis/grida/client/GRIDAClientMain.java
@@ -35,8 +35,6 @@ import fr.insalyon.creatis.grida.common.bean.GridData;
 import fr.insalyon.creatis.grida.common.bean.GridPathInfo;
 import fr.insalyon.creatis.grida.common.bean.Operation;
 import fr.insalyon.creatis.grida.common.bean.ZombieFile;
-
-
 import java.io.File;
 import java.text.DateFormat;
 import java.util.Arrays;

--- a/grida-common/src/main/java/fr/insalyon/creatis/grida/common/ExecutorConstants.java
+++ b/grida-common/src/main/java/fr/insalyon/creatis/grida/common/ExecutorConstants.java
@@ -53,6 +53,7 @@ public class ExecutorConstants {
     public static final int COM_RENAME = 110;
     public static final int COM_EXIST = 111;
     public static final int COM_SET_COMMENT = 112;
+    public static final int COM_GET_PATH_INFO = 113;
     // Cache Commands
     public static final int CACHE_LIST_FILES = 201;
     public static final int CACHE_DELETE_FILE = 202;

--- a/grida-common/src/main/java/fr/insalyon/creatis/grida/common/bean/GridPathInfo.java
+++ b/grida-common/src/main/java/fr/insalyon/creatis/grida/common/bean/GridPathInfo.java
@@ -1,0 +1,18 @@
+package fr.insalyon.creatis.grida.common.bean;
+
+public class GridPathInfo {
+    private boolean doesExist;
+    private GridData.Type type;
+
+    public GridPathInfo(boolean exist, GridData.Type type) {
+        this.doesExist = exist;
+        this.type = type;
+    }
+
+    public boolean exist() {
+        return doesExist;
+    }
+    public GridData.Type getType() {
+        return type;
+    }
+}

--- a/grida-common/src/main/java/fr/insalyon/creatis/grida/common/bean/GridPathInfo.java
+++ b/grida-common/src/main/java/fr/insalyon/creatis/grida/common/bean/GridPathInfo.java
@@ -2,7 +2,7 @@ package fr.insalyon.creatis.grida.common.bean;
 
 public class GridPathInfo {
     private boolean doesExist;
-    private GridData.Type type;
+    private GridData.Type type; // type is undefined and can be null when doesExist is false
 
     public GridPathInfo(boolean exist, GridData.Type type) {
         this.doesExist = exist;

--- a/grida-server/pom.xml
+++ b/grida-server/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.3.169</version>
+            <version>1.4.196</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/grida-server/pom.xml
+++ b/grida-server/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.196</version>
+            <version>1.3.169</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/grida-server/src/main/java/fr/insalyon/creatis/grida/server/business/OperationBusiness.java
+++ b/grida-server/src/main/java/fr/insalyon/creatis/grida/server/business/OperationBusiness.java
@@ -81,6 +81,14 @@ public class OperationBusiness {
         }
     }
 
+    public GridData.Type getPathInfo(String path) throws BusinessException {
+        try {
+            return operations.getPathInfo(proxy, path);
+        } catch (OperationException ex) {
+            throw new BusinessException(ex);
+        }
+    }
+
     public List<GridData> listFilesAndFolders(String path)
         throws BusinessException {
 

--- a/grida-server/src/main/java/fr/insalyon/creatis/grida/server/business/OperationBusiness.java
+++ b/grida-server/src/main/java/fr/insalyon/creatis/grida/server/business/OperationBusiness.java
@@ -36,6 +36,7 @@ package fr.insalyon.creatis.grida.server.business;
 
 import fr.insalyon.creatis.devtools.zip.FolderZipper;
 import fr.insalyon.creatis.grida.common.bean.GridData;
+import fr.insalyon.creatis.grida.common.bean.GridPathInfo;
 import fr.insalyon.creatis.grida.server.Configuration;
 import fr.insalyon.creatis.grida.server.operation.Operations;
 import fr.insalyon.creatis.grida.server.operation.OperationException;
@@ -81,7 +82,7 @@ public class OperationBusiness {
         }
     }
 
-    public GridData.Type getPathInfo(String path) throws BusinessException {
+    public GridPathInfo getPathInfo(String path) throws BusinessException {
         try {
             return operations.getPathInfo(proxy, path);
         } catch (OperationException ex) {

--- a/grida-server/src/main/java/fr/insalyon/creatis/grida/server/execution/Executor.java
+++ b/grida-server/src/main/java/fr/insalyon/creatis/grida/server/execution/Executor.java
@@ -101,6 +101,9 @@ public class Executor extends Thread {
                 case ExecutorConstants.COM_LIST_FILES_AND_FOLDERS:
                     return new ListFilesAndFoldersCommand(communication, proxy, tokens[2], tokens[3]);
 
+                case ExecutorConstants.COM_GET_PATH_INFO:
+                    return new GetPathInfoCommand(communication, proxy, tokens[2].split(Constants.MSG_SEP_2));
+
                 case ExecutorConstants.COM_GET_MODIFICATION_DATE:
                     return new GetModificationDateCommand(communication, proxy, tokens[2].split(Constants.MSG_SEP_2));
 

--- a/grida-server/src/main/java/fr/insalyon/creatis/grida/server/execution/command/GetPathInfoCommand.java
+++ b/grida-server/src/main/java/fr/insalyon/creatis/grida/server/execution/command/GetPathInfoCommand.java
@@ -1,6 +1,8 @@
 package fr.insalyon.creatis.grida.server.execution.command;
 
 import fr.insalyon.creatis.grida.common.Communication;
+import fr.insalyon.creatis.grida.common.Constants;
+import fr.insalyon.creatis.grida.common.bean.GridPathInfo;
 import fr.insalyon.creatis.grida.server.business.BusinessException;
 import fr.insalyon.creatis.grida.server.business.OperationBusiness;
 import fr.insalyon.creatis.grida.server.execution.Command;
@@ -20,7 +22,9 @@ public class GetPathInfoCommand extends Command {
     public void execute() {
         try {
             for (String pathName : paths) {
-                communication.sendMessage(operationBusiness.getPathInfo(pathName) + "");
+                GridPathInfo pathInfo = operationBusiness.getPathInfo(pathName);
+                String message = pathInfo.exist() + Constants.MSG_SEP_2 + pathInfo.getType();
+                communication.sendMessage(message);
             }
         } catch (BusinessException ex) {
             communication.sendErrorMessage(ex.getMessage());

--- a/grida-server/src/main/java/fr/insalyon/creatis/grida/server/execution/command/GetPathInfoCommand.java
+++ b/grida-server/src/main/java/fr/insalyon/creatis/grida/server/execution/command/GetPathInfoCommand.java
@@ -1,0 +1,30 @@
+package fr.insalyon.creatis.grida.server.execution.command;
+
+import fr.insalyon.creatis.grida.common.Communication;
+import fr.insalyon.creatis.grida.server.business.BusinessException;
+import fr.insalyon.creatis.grida.server.business.OperationBusiness;
+import fr.insalyon.creatis.grida.server.execution.Command;
+
+public class GetPathInfoCommand extends Command {
+    private String[] paths;
+    private OperationBusiness operationBusiness;
+
+    public GetPathInfoCommand(Communication communication,
+                                      String proxyFileName, String... paths) {
+        super(communication, proxyFileName);
+        this.paths = paths;
+        operationBusiness = new OperationBusiness(proxyFileName);
+    }
+
+    @Override
+    public void execute() {
+        try {
+            for (String pathName : paths) {
+                communication.sendMessage(operationBusiness.getPathInfo(pathName) + "");
+            }
+        } catch (BusinessException ex) {
+            communication.sendErrorMessage(ex.getMessage());
+        }
+        communication.sendEndOfMessage();
+    }
+}

--- a/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/DiracOperations.java
+++ b/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/DiracOperations.java
@@ -99,21 +99,21 @@ public class DiracOperations implements Operations {
                 "dirac-dms-lfn-metadata " + path +
                         " | grep -e \\'DirID\\' -e \\'FileID\\' | sed 's/^ *//'");
         boolean exist;
-        GridData.Type type;
+        GridData.Type type = null;
         if (output.isEmpty()) {
             exist = false;
         } else {
             exist = true;
-        }
-        String result = output.get(0);
-        if (result == "'DirID':") {
-            type = GridData.Type.Folder;
-        } else if (result == "'FileID':") {
-            type = GridData.Type.File;
-        } else {
-            String error = "[dirac] Cannot get path info for '" + path + "': unknown type";
-            logger.error(error);
-            throw new OperationException(error);
+            String result = output.get(0);
+            if (result.startsWith("'DirID':")) {
+                type = GridData.Type.Folder;
+            } else if (result.startsWith("'FileID':")) {
+                type = GridData.Type.File;
+            } else {
+                String error = "[dirac] Cannot get path info for '" + path + "': unknown type";
+                logger.error(error);
+                throw new OperationException(error);
+            }
         }
         return new GridPathInfo(exist, type);
     }

--- a/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/DiracOperations.java
+++ b/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/DiracOperations.java
@@ -31,10 +31,10 @@
 package fr.insalyon.creatis.grida.server.operation;
 
 import fr.insalyon.creatis.grida.common.bean.GridData;
+import fr.insalyon.creatis.grida.common.bean.GridPathInfo;
 import fr.insalyon.creatis.grida.server.Configuration;
 import fr.insalyon.creatis.grida.server.business.DiskspaceManager;
 import fr.insalyon.creatis.grida.server.execution.PoolProcessManager;
-import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 
 import java.io.*;
@@ -89,29 +89,33 @@ public class DiracOperations implements Operations {
     }
 
     @Override
-    public GridData.Type getPathInfo(String proxy, String path) throws OperationException {
+    public GridPathInfo getPathInfo(String proxy, String path) throws OperationException {
         logger.info("[dirac] Getting path info for: " + path);
+        // on non-existence, exit code is 0 and output is empty, as in exists(),
+        // because sed always succeed even when grep matches nothing
         List<String> output = executeCommand(
                 proxy,
                 "Unable to get path info for " + path,
                 "dirac-dms-lfn-metadata " + path +
-                        " | grep -e \\'DirID\\' -e \\'FileID\\' | head -n1 | sed 's/^ *//'");
+                        " | grep -e \\'DirID\\' -e \\'FileID\\' | sed 's/^ *//'");
+        boolean exist;
+        GridData.Type type;
         if (output.isEmpty()) {
-            String error =
-                    "[dirac] Cannot get path info for '" + path + "' because it does not exist";
-            logger.error(error);
-            throw new OperationException(error);
+            exist = false;
+        } else {
+            exist = true;
         }
         String result = output.get(0);
         if (result == "'DirID':") {
-            return GridData.Type.Folder;
+            type = GridData.Type.Folder;
         } else if (result == "'FileID':") {
-            return GridData.Type.File;
+            type = GridData.Type.File;
         } else {
             String error = "[dirac] Cannot get path info for '" + path + "': unknown type";
             logger.error(error);
             throw new OperationException(error);
         }
+        return new GridPathInfo(exist, type);
     }
 
     @Override

--- a/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/DiracOperations.java
+++ b/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/DiracOperations.java
@@ -89,6 +89,32 @@ public class DiracOperations implements Operations {
     }
 
     @Override
+    public GridData.Type getPathInfo(String proxy, String path) throws OperationException {
+        logger.info("[dirac] Getting path info for: " + path);
+        List<String> output = executeCommand(
+                proxy,
+                "Unable to get path info for " + path,
+                "dirac-dms-lfn-metadata " + path +
+                        " | grep -e \\'DirID\\' -e \\'FileID\\' | head -n1 | sed 's/^ *//'");
+        if (output.isEmpty()) {
+            String error =
+                    "[dirac] Cannot get path info for '" + path + "' because it does not exist";
+            logger.error(error);
+            throw new OperationException(error);
+        }
+        String result = output.get(0);
+        if (result == "'DirID':") {
+            return GridData.Type.Folder;
+        } else if (result == "'FileID':") {
+            return GridData.Type.File;
+        } else {
+            String error = "[dirac] Cannot get path info for '" + path + "': unknown type";
+            logger.error(error);
+            throw new OperationException(error);
+        }
+    }
+
+    @Override
     public List<GridData> listFilesAndFolders(String proxy, String path) throws OperationException {
 
         logger.info("[dirac] Listing contents of: " + path);

--- a/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/LocalOperations.java
+++ b/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/LocalOperations.java
@@ -2,6 +2,7 @@ package fr.insalyon.creatis.grida.server.operation;
 
 import fr.insalyon.creatis.grida.common.bean.GridData;
 import fr.insalyon.creatis.grida.common.bean.GridData.Type;
+import fr.insalyon.creatis.grida.common.bean.GridPathInfo;
 import fr.insalyon.creatis.grida.server.business.DiskspaceManager;
 
 import org.apache.commons.io.FileUtils;
@@ -38,17 +39,18 @@ public class LocalOperations implements Operations {
     }
 
     @Override
-    public GridData.Type getPathInfo(String proxy, String path) throws OperationException {
+    public GridPathInfo getPathInfo(String proxy, String path) throws OperationException {
         File file = new File(path);
-        if (!file.exists()) {
-            throw new OperationException("Path " + path + " does not exist");
-        } else if (file.isDirectory()) {
-            return GridData.Type.Folder;
-        } else if (file.isFile()) {
-            return GridData.Type.File;
-        } else { // special file (socket, device, ...)
-            throw new OperationException("Path " + path + " is neither a regular file nor a directory");
+        boolean exist = file.exists();
+        GridData.Type type;
+        if (file.isDirectory()) {
+            type = GridData.Type.Folder;
+        } else {
+            // file.isFile() may still be false here, for non-regular files such as device or socket.
+            // we still report "File" type anyway, as these special files do not matter to VIP.
+            type = GridData.Type.File;
         }
+        return new GridPathInfo(exist, type);
     }
 
     @Override

--- a/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/LocalOperations.java
+++ b/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/LocalOperations.java
@@ -42,13 +42,15 @@ public class LocalOperations implements Operations {
     public GridPathInfo getPathInfo(String proxy, String path) throws OperationException {
         File file = new File(path);
         boolean exist = file.exists();
-        GridData.Type type;
-        if (file.isDirectory()) {
-            type = GridData.Type.Folder;
-        } else {
-            // file.isFile() may still be false here, for non-regular files such as device or socket.
-            // we still report "File" type anyway, as these special files do not matter to VIP.
-            type = GridData.Type.File;
+        GridData.Type type = null;
+        if (exist) {
+            if (file.isDirectory()) {
+                type = GridData.Type.Folder;
+            } else {
+                // file.isFile() may still be false here, for non-regular files such as device or socket.
+                // we still report "File" type anyway, as these special files do not matter to VIP.
+                type = GridData.Type.File;
+            }
         }
         return new GridPathInfo(exist, type);
     }

--- a/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/LocalOperations.java
+++ b/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/LocalOperations.java
@@ -38,6 +38,20 @@ public class LocalOperations implements Operations {
     }
 
     @Override
+    public GridData.Type getPathInfo(String proxy, String path) throws OperationException {
+        File file = new File(path);
+        if (!file.exists()) {
+            throw new OperationException("Path " + path + " does not exist");
+        } else if (file.isDirectory()) {
+            return GridData.Type.Folder;
+        } else if (file.isFile()) {
+            return GridData.Type.File;
+        } else { // special file (socket, device, ...)
+            throw new OperationException("Path " + path + " is neither a regular file nor a directory");
+        }
+    }
+
+    @Override
     public List<GridData> listFilesAndFolders(String proxy, String path) throws OperationException {
         if ( ! exists(proxy, path)) {
             return Collections.emptyList();

--- a/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/Operations.java
+++ b/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/Operations.java
@@ -42,6 +42,11 @@ public interface Operations {
         throws OperationException;
 
     /**
+     * @return the path type (file or folder)
+     */
+    GridData.Type getPathInfo(String proxy, String path) throws OperationException;
+
+    /**
      * @return if path is a folder, the list of GridData about the files/folder
      * of this folder. If path is a file, it returns a list with a single
      * GridData about this file. If path does not exist, returns an empty list

--- a/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/Operations.java
+++ b/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/Operations.java
@@ -31,6 +31,8 @@
 package fr.insalyon.creatis.grida.server.operation;
 
 import fr.insalyon.creatis.grida.common.bean.GridData;
+import fr.insalyon.creatis.grida.common.bean.GridPathInfo;
+
 import java.util.List;
 
 public interface Operations {
@@ -42,9 +44,9 @@ public interface Operations {
         throws OperationException;
 
     /**
-     * @return the path type (file or folder)
+     * @return the path info (existence and folder or file type)
      */
-    GridData.Type getPathInfo(String proxy, String path) throws OperationException;
+    GridPathInfo getPathInfo(String proxy, String path) throws OperationException;
 
     /**
      * @return if path is a folder, the list of GridData about the files/folder

--- a/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/Operations.java
+++ b/grida-server/src/main/java/fr/insalyon/creatis/grida/server/operation/Operations.java
@@ -32,7 +32,6 @@ package fr.insalyon.creatis.grida.server.operation;
 
 import fr.insalyon.creatis.grida.common.bean.GridData;
 import fr.insalyon.creatis.grida.common.bean.GridPathInfo;
-
 import java.util.List;
 
 public interface Operations {


### PR DESCRIPTION
This adds a new `getPathInfo()` command to Grida, which takes a path as input, and returns a new `GridPathInfo` structure, indicating if the path exists, and whether it is a directory or a file.
On Dirac, this is implemented as a single call to `dirac-dms-lfn-metadata` to get both existence and type, and the existence test is consistent with the current `exists()` command.
