### PR TITLE
Fix NPE in grida-server

### DIFF
--- a/grida-server/src/main/java/fr/insalyon/creatis/grida/server/Configuration.java
+++ b/grida-server/src/main/java/fr/insalyon/creatis/grida/server/Configuration.java
@@ -102,7 +102,7 @@ public class Configuration {
         } else {
             loadConfigurationFile(confFile);
         }
-        if (features.hasCache) {
+        if (this.features.hasCache) {
             createCachePath();
         }
         switch (commandsType) {


### PR DESCRIPTION
This fixes a bug currently on `develop`, where the `features` argument to GRIDA server Configuration can be `null`, but is still dereferenced. In practice, this causes grida-server to crash on startup. grida-standalone is not impacted.

The bug was recently introduced in a late commit (https://github.com/virtual-imaging-platform/GRIDA/pull/45/commits/75a4f605501995714fdbf9572a60f0baaa740afa) of PR https://github.com/virtual-imaging-platform/GRIDA/pull/45.
